### PR TITLE
fix(parser): prune out null addresses in bulk

### DIFF
--- a/lib/postmark-transport.js
+++ b/lib/postmark-transport.js
@@ -17,7 +17,7 @@ function parseAddress(address, parseBulk) {
   const addrs = addressParser(address || '');
 
   return parseBulk
-    ? (addrs || []).map(addressFormatter).join(',')
+    ? (addrs || []).filter(Boolean).map(addressFormatter).join(',')
     : addressFormatter(addrs[0] || {});
 }
 

--- a/test/postmark-transport.test.js
+++ b/test/postmark-transport.test.js
@@ -138,6 +138,7 @@ describe('PostmarkTransport', () => {
 
       it('should parse mixed address formats in to / cc / bcc fields', (done) => {
         const address = [
+          null, // If per chance happens to be a null address, it should get pruned
           'foo@example.org',
           '"Bar Bar" bar@example.org',
           '"Jane Doe" <jane.doe@example.org>, "John, Doe" <john.doe@example.org>',


### PR DESCRIPTION
If there is a `null` address in an address array, Postmark rejects the email.

For example, this will fail

```
const addresses = [null, 'shane@northernv.com'];
```