### PR TITLE
feat: Add originalResults field to the SendMessageInfo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Models, Client } from 'postmark'
+import { Models, Client } from 'postmark';
 
 declare module 'nodemailer-postmark-transport' {
   type Callback<T> = (error: (Error | null), result: (T | null)) => void;
@@ -7,6 +7,7 @@ declare module 'nodemailer-postmark-transport' {
     messageId?: string;
     accepted: Array<Models.MessageSendingResponse>;
     rejected: Array<Models.MessageSendingResponse>;
+    originalResults: Array<Models.MessageSendingResponse>;
   }
 
   export interface PostmarkTransportOptions {

--- a/lib/postmark-transport.js
+++ b/lib/postmark-transport.js
@@ -202,16 +202,16 @@ PostmarkTransport.prototype._requestFactory = function (method) {
     const accepted = [];
     const rejected = [];
 
-    this.client[method](payload, (err, results) => {
+    this.client[method](payload, (err, originalResults) => {
       if (err) {
         return callback(err);
       }
 
-      if (!Array.isArray(results)) {
-        results = [results];
+      if (!Array.isArray(originalResults)) {
+        originalResults = [originalResults];
       }
 
-      results.forEach((result) => {
+      originalResults.forEach((result) => {
         if (result.ErrorCode === 0) {
           accepted.push(result);
         } else {
@@ -220,9 +220,10 @@ PostmarkTransport.prototype._requestFactory = function (method) {
       });
 
       return callback(null, {
-        messageId: (results[0] || {}).MessageID,
+        messageId: (originalResults[0] || {}).MessageID,
         accepted: accepted,
-        rejected: rejected
+        rejected: rejected,
+        originalResults
       });
     });
   };


### PR DESCRIPTION
This pull request adds an originalResults field to the SendMessageInfo interface in the nodemailer-postmark-transport module. This field will contain the original Postmark results of the message sending operation which retains the order of results so they can be matched with the submitted messages.